### PR TITLE
Fix: Allow big files to be uploaded and then analyzed by Windup

### DIFF
--- a/windup-api-with-tackle.yaml
+++ b/windup-api-with-tackle.yaml
@@ -2395,6 +2395,8 @@ metadata:
     app.kubernetes.io/component: application
     app.kubernetes.io/instance: tackle
     app.kubernetes.io/part-of: tackle
+annotations:
+  nginx.ingress.kubernetes.io/proxy-body-size: 100M
 spec:
   rules:
     - http:

--- a/windup-api-with-tackle.yaml
+++ b/windup-api-with-tackle.yaml
@@ -2395,8 +2395,8 @@ metadata:
     app.kubernetes.io/component: application
     app.kubernetes.io/instance: tackle
     app.kubernetes.io/part-of: tackle
-annotations:
-  nginx.ingress.kubernetes.io/proxy-body-size: 100M
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "100M"
 spec:
   rules:
     - http:


### PR DESCRIPTION
## Steps to test this PR

Start Minikube:
```
minikube start --disk-size 20GB
```

Enable the Ingress addon in Minikube:
```
minikube addons enable ingress
```

Create a namespace:
```
kubectl create namespace windup
```

Create all resources required (the command below points to the file changed in the PR):
```
kubectl apply -n windup -f https://raw.githubusercontent.com/carlosthe19916/windup-api/fix-upload-max-size/windup-api-with-tackle.yaml
```

Enter to the Tackle UI url (ingress created by Minikube) and analyze a file of 80 MB, the upload an analysis should be successfully an you no longer will see the 413 error code.