### PR TITLE
E2E test

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -34,12 +34,25 @@ jobs:
           distribution: 'adopt'
           java-package: jdk
 
+      - name: Build Tackle Windup API container image
+        run: |
+          ./mvnw package -Pcontainer \
+              -Dquarkus.container-image.tag=test \
+              -Dquarkus.container-image.push=false \
+              -Dquarkus.container-image.group=$USER \
+              -Dquarkus.container-image.registry=localhost
+          minikube image load localhost/$USER/windup-api:test
+
       - name: Deploy Tackle Windup API (following README instructions)
         run: |
          kubectl create namespace ${{env.kubernetes_namespace}}
-         sed "s/{user}/$USER/g" minikube-development.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
+         sed "s\quay.io/windupeng/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
+         kubectl wait -n ${{env.kubernetes_namespace}} --for condition=Available deployment windup-api --timeout=-1s
+
+      - name: Wait for Tackle Windup API (following README instructions)
+        run: |
          kubectl wait -n ${{env.kubernetes_namespace}} --for condition=Available deployment windup-api --timeout=-1s
 
       - name: E2E test Tackle Windup API
         run: |
-         ./mvnw verify -Pcontainer -Pminikube -Dwindup.url=$(minikube service -n ${{env.kubernetes_namespace}} api --url)
+         ./mvnw verify -Dwindup.url=$(minikube service -n ${{env.kubernetes_namespace}} api --url)

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -34,6 +34,13 @@ jobs:
           distribution: 'adopt'
           java-package: jdk
 
+      - name: Cache Maven packages
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
       - name: Build Tackle Windup API container image
         run: |
           ./mvnw package -Pcontainer \

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -56,8 +56,6 @@ jobs:
         run: |
          kubectl create namespace ${{env.kubernetes_namespace}}
          sed "s\localhost/{user}/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube-development.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
-         sleep 30
-         kubectl -n ${{env.kubernetes_namespace}} describe deployments
 
       - name: Wait for Tackle Windup API (following README instructions)
         run: |

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -56,8 +56,8 @@ jobs:
         run: |
          kubectl create namespace ${{env.kubernetes_namespace}}
          kubectl apply -n ${{env.kubernetes_namespace}} -f minikube.yaml
-#         sed "s\quay.io/windupeng/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
          watch kubectl -n ${{env.kubernetes_namespace}} describe deployments
+#         sed "s\quay.io/windupeng/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
 
       - name: Wait for Tackle Windup API (following README instructions)
         run: |

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -29,36 +29,35 @@ jobs:
           kubernetes version: ${{ matrix.kubernetes_version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
 
-#      - name: Setup Java 11
-#        uses: actions/setup-java@v2
-#        with:
-#          java-version: '11'
-#          distribution: 'adopt'
-#          java-package: jdk
-#
-#      - name: Cache Maven packages
-#        uses: actions/cache@v2.1.6
-#        with:
-#          path: ~/.m2
-#          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-#          restore-keys: ${{ runner.os }}-m2
-#
-#      - name: Build Tackle Windup API container image
-#        run: |
-#          ./mvnw package -Pcontainer \
-#              -Dquarkus.container-image.tag=test \
-#              -Dquarkus.container-image.push=false \
-#              -Dquarkus.container-image.group=$USER \
-#              -Dquarkus.container-image.registry=localhost
-#          minikube image load localhost/$USER/windup-api:test
+      - name: Setup Java 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          java-package: jdk
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build Tackle Windup API container image
+        run: |
+          ./mvnw package -Pcontainer \
+              -Dquarkus.container-image.tag=test \
+              -Dquarkus.container-image.push=false \
+              -Dquarkus.container-image.group=$USER \
+              -Dquarkus.container-image.registry=localhost
+          minikube image load localhost/$USER/windup-api:test
 
       - name: Deploy Tackle Windup API (following README instructions)
         run: |
          kubectl create namespace ${{env.kubernetes_namespace}}
-         kubectl apply -n ${{env.kubernetes_namespace}} -f minikube.yaml
+         sed "s\localhost/{user}/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube-development.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
          sleep 30
          kubectl -n ${{env.kubernetes_namespace}} describe deployments
-#         sed "s\quay.io/windupeng/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
 
       - name: Wait for Tackle Windup API (following README instructions)
         run: |

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -29,3 +29,13 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
           java-package: jdk
+
+      -name: Deploy Tackle Windup API (following README instructions)
+       run: |
+         kubectl create namespace ${{env.kubernetes_namespace}}
+         sed "s/{user}/$USER/g" minikube-development.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
+         kubectl wait -n ${{env.kubernetes_namespace}} --for condition=Available deployment windup-api --timeout=-1s
+
+      -name: E2E test Tackle Windup API
+       run: |
+         ./mvnw verify -Pcontainer -Pminikube -Dwindup.url=$(minikube service -n ${{env.kubernetes_namespace}} api --url)

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -56,7 +56,8 @@ jobs:
         run: |
          kubectl create namespace ${{env.kubernetes_namespace}}
          kubectl apply -n ${{env.kubernetes_namespace}} -f minikube.yaml
-         watch kubectl -n ${{env.kubernetes_namespace}} describe deployments
+         sleep 30
+         kubectl -n ${{env.kubernetes_namespace}} describe deployments
 #         sed "s\quay.io/windupeng/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
 
       - name: Wait for Tackle Windup API (following README instructions)

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Wait for Tackle Windup API (following README instructions)
         run: |
-         kubectl wait -n ${{env.kubernetes_namespace}} --for condition=Available deployment windup-api --timeout=-1s
+         kubectl -n ${{env.kubernetes_namespace}} describe deployments
+         kubectl wait -n ${{env.kubernetes_namespace}} --for condition=available deployment windup-api --timeout=-1s
 
       - name: E2E test Tackle Windup API
         run: |

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -2,11 +2,9 @@ name: Tackle Windup API E2E Tests
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
   push:
-    branches:
-      - main
+    branches: [ main ]
 
 jobs:
   minikube:
@@ -36,12 +34,12 @@ jobs:
           distribution: 'adopt'
           java-package: jdk
 
-      -name: Deploy Tackle Windup API (following README instructions)
-       run: |
+      - name: Deploy Tackle Windup API (following README instructions)
+        run: |
          kubectl create namespace ${{env.kubernetes_namespace}}
          sed "s/{user}/$USER/g" minikube-development.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
          kubectl wait -n ${{env.kubernetes_namespace}} --for condition=Available deployment windup-api --timeout=-1s
 
-      -name: E2E test Tackle Windup API
-       run: |
+      - name: E2E test Tackle Windup API
+        run: |
          ./mvnw verify -Pcontainer -Pminikube -Dwindup.url=$(minikube service -n ${{env.kubernetes_namespace}} api --url)

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -29,34 +29,35 @@ jobs:
           kubernetes version: ${{ matrix.kubernetes_version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Java 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          java-package: jdk
-
-      - name: Cache Maven packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: Build Tackle Windup API container image
-        run: |
-          ./mvnw package -Pcontainer \
-              -Dquarkus.container-image.tag=test \
-              -Dquarkus.container-image.push=false \
-              -Dquarkus.container-image.group=$USER \
-              -Dquarkus.container-image.registry=localhost
-          minikube image load localhost/$USER/windup-api:test
+#      - name: Setup Java 11
+#        uses: actions/setup-java@v2
+#        with:
+#          java-version: '11'
+#          distribution: 'adopt'
+#          java-package: jdk
+#
+#      - name: Cache Maven packages
+#        uses: actions/cache@v2.1.6
+#        with:
+#          path: ~/.m2
+#          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+#          restore-keys: ${{ runner.os }}-m2
+#
+#      - name: Build Tackle Windup API container image
+#        run: |
+#          ./mvnw package -Pcontainer \
+#              -Dquarkus.container-image.tag=test \
+#              -Dquarkus.container-image.push=false \
+#              -Dquarkus.container-image.group=$USER \
+#              -Dquarkus.container-image.registry=localhost
+#          minikube image load localhost/$USER/windup-api:test
 
       - name: Deploy Tackle Windup API (following README instructions)
         run: |
          kubectl create namespace ${{env.kubernetes_namespace}}
-         sed "s\quay.io/windupeng/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
-         kubectl -n ${{env.kubernetes_namespace}} describe deployments
+         kubectl apply -n ${{env.kubernetes_namespace}} -f minikube.yaml
+#         sed "s\quay.io/windupeng/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
+         watch kubectl -n ${{env.kubernetes_namespace}} describe deployments
 
       - name: Wait for Tackle Windup API (following README instructions)
         run: |

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -1,13 +1,15 @@
-name: Tackle Windup API E2E Tests
+name: Tackle Windup API Tests
 
 on:
   pull_request:
     branches: [ main ]
   push:
     branches: [ main ]
+  schedule:
+    - cron: '0 8 * * *'
 
 jobs:
-  minikube:
+  E2E:
     name: minikube
     runs-on: ubuntu-latest
     strategy:
@@ -54,7 +56,6 @@ jobs:
         run: |
          kubectl create namespace ${{env.kubernetes_namespace}}
          sed "s\quay.io/windupeng/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
-         kubectl wait -n ${{env.kubernetes_namespace}} --for condition=Available deployment windup-api --timeout=-1s
 
       - name: Wait for Tackle Windup API (following README instructions)
         run: |

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -56,10 +56,10 @@ jobs:
         run: |
          kubectl create namespace ${{env.kubernetes_namespace}}
          sed "s\quay.io/windupeng/windup-api:0.0.1-SNAPSHOT\localhost/$USER/windup-api:test\g" minikube.yaml | kubectl apply -n ${{env.kubernetes_namespace}} -f -
+         kubectl -n ${{env.kubernetes_namespace}} describe deployments
 
       - name: Wait for Tackle Windup API (following README instructions)
         run: |
-         kubectl -n ${{env.kubernetes_namespace}} describe deployments
          kubectl wait -n ${{env.kubernetes_namespace}} --for condition=available deployment windup-api --timeout=-1s
 
       - name: E2E test Tackle Windup API

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -1,6 +1,12 @@
 name: Tackle Windup API E2E Tests
 
-on: [pull_request,push]
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   minikube:

--- a/minikube-development.yaml
+++ b/minikube-development.yaml
@@ -305,3 +305,4 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 10
+          imagePullPolicy: IfNotPresent

--- a/minikube-development.yaml
+++ b/minikube-development.yaml
@@ -1,0 +1,307 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: shared-analysis
+  labels:
+    app.kubernetes.io/name: shared-analysis
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: shared-analysis
+    app.kubernetes.io/part-of: windup-api
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  volumeMode: Filesystem
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: central-graph
+  labels:
+    app.kubernetes.io/name: central-graph
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: central-graph
+    app.kubernetes.io/part-of: windup-api
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # 10 Gi due to https://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/EnvironmentConfig.html#FREE_DISK
+      storage: 10Gi
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: artemis
+  labels:
+    app.kubernetes.io/name: artemis
+    app.kubernetes.io/component: jms-broker
+    app.kubernetes.io/instance: artemis
+    app.kubernetes.io/part-of: windup-api
+spec:
+  ports:
+    - name: tcp
+      protocol: TCP
+      port: 61616
+      targetPort: 61616
+  selector:
+    app.kubernetes.io/name: artemis
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: artemis-console
+  labels:
+    app.kubernetes.io/name: artemis-console
+    app.kubernetes.io/component: jms-broker
+    app.kubernetes.io/instance: artemis-console
+    app.kubernetes.io/part-of: windup-api
+spec:
+  ports:
+    - name: http
+      port: 8161
+      targetPort: 8161
+  selector:
+    app.kubernetes.io/name: artemis
+  type: LoadBalancer
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: api
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/component: windup-api
+    app.kubernetes.io/instance: api
+    app.kubernetes.io/part-of: windup-api
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: windup-api
+  type: LoadBalancer
+  sessionAffinity: None
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: artemis
+  labels:
+    app.kubernetes.io/name: artemis
+    app.kubernetes.io/component: jms-broker
+    app.kubernetes.io/instance: artemis
+    app.kubernetes.io/part-of: windup-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: artemis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: artemis
+    spec:
+      containers:
+        - name: artemis
+          image: quay.io/artemiscloud/activemq-artemis-broker:0.1.4
+          ports:
+            - containerPort: 61616
+              protocol: TCP
+            - containerPort: 8161
+              protocol: TCP
+          env:
+            - name: AMQ_USER
+              value: quarkus
+            - name: AMQ_PASSWORD
+              value: quarkus
+          resources: {}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8161
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8161
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: "/dev/termination-log"
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: false
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: windup-executor
+  labels:
+    app.kubernetes.io/name: windup-executor
+    app.kubernetes.io/component: windup
+    app.kubernetes.io/instance: windup-executor
+    app.kubernetes.io/part-of: windup-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: windup-executor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: windup-executor
+    spec:
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: shared-analysis
+      containers:
+        - name: windup-executor
+#          image: localhost/mrizzi/windup-web-openshift-messaging-executor:5.2.1-SNAPSHOT
+          image: quay.io/mrizzi/windup-web-openshift-messaging-executor:prototype
+#          resources:
+#            requests:
+#              cpu: 2
+#              memory: 4Gi
+#            limits:
+#              cpu: 2
+#              memory: 4Gi
+          env:
+            - name: MESSAGING_USER
+              value: "quarkus"
+            - name: MESSAGING_PASSWORD
+              value: "quarkus"
+            - name: MESSAGING_HOST_VAR
+              value: "jms-url"
+            - name: JMS_URL
+              value: "ARTEMIS"
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /opt/windup/shared
+          lifecycle:
+            preStop:
+              exec:
+                command: 
+                  - /opt/mta-cli/bin/stop.sh
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - "-c"
+                - /opt/mta-cli/bin/livenessProbe.sh
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - "-c"
+                - /opt/mta-cli/bin/livenessProbe.sh
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 6
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: windup-api
+  labels:
+    app.kubernetes.io/name: windup-api
+    app.kubernetes.io/component: API
+    app.kubernetes.io/instance: windup-api
+    app.kubernetes.io/part-of: windup-api
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: windup-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: windup-api
+    spec:
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: shared-analysis
+        - name: central-graph
+          persistentVolumeClaim:
+            claimName: central-graph
+      initContainers:
+        - name: init-config
+          image: busybox:latest
+          command: ['sh', '-c', "until wget -T 1 http://${ARTEMIS_CONSOLE_SERVICE_HOST}:${ARTEMIS_CONSOLE_SERVICE_PORT}/; do echo waiting for artemis; sleep 2; done"]
+      containers:
+        - name: windup-api
+          image: localhost/{user}/windup-api:0.0.1-SNAPSHOT
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            - name: ORG_JBOSS_WINDUP_WEB_SHARED_FOLDER_PATH
+              value: "/opt/windup/shared"
+            - name: QUARKUS_ARTEMIS_URL
+              value: "tcp://artemis:61616"
+            - name: QUARKUS_LOG_LEVEL
+#              value: "DEBUG"
+              value: "INFO"
+            - name: QUARKUS_HTTP_LIMITS_MAX_BODY_SIZE
+              value: "100M"
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /opt/windup/shared/
+            - name: central-graph
+              mountPath: /opt/windup/central-graph/
+          livenessProbe:
+            httpGet:
+              path: /q/health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 120
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /q/health/ready
+              port: 8080
+              scheme: HTTP
+            failureThreshold: 3
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,16 @@
         <artifactId>commons-logging-jboss-logging</artifactId>
         <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -298,6 +308,25 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                <maven.home>${maven.home}</maven.home>
+              </systemPropertyVariables>
+              <trimStackTrace>false</trimStackTrace>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -333,6 +362,17 @@
       </build>
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
+    <profile>
+      <id>container</id>
+      <activation>
+        <property>
+          <name>container</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.container-image.build>true</quarkus.container-image.build>
       </properties>
     </profile>
     <profile>
@@ -407,7 +447,7 @@
                   <arguments>
                     <argument>${project.artifactId}</argument>
                     <argument>${project.version}</argument>
-<!--                    <argument>${quarkus.package.type}</argument>-->
+                    <argument>windup-api</argument>
                   </arguments>
                   <async>false</async>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,13 @@
         <property>
           <name>!env.DOCKER_HOST</name>
         </property>
+        <file>
+          <missing>/var/run/docker.sock</missing>
+        </file>
+        <os>
+          <name>linux</name>
+          <family>unix</family>
+        </os>
       </activation>
       <build>
         <plugins>

--- a/src/test/java/org/jboss/windup/web/rest/WindupE2EIT.java
+++ b/src/test/java/org/jboss/windup/web/rest/WindupE2EIT.java
@@ -40,10 +40,7 @@ public class WindupE2EIT {
         final WebTarget target = client.target(String.format("%s/%s/analysisSse/", URL, PATH));
         final List<String> received = new CopyOnWriteArrayList<>();
         final SseEventSource source = SseEventSource.target(target).build();
-        source.register(inboundSseEvent -> {
-            System.out.println("inboundSseEvent = " + inboundSseEvent.readData());
-            received.add(inboundSseEvent.readData());
-        });
+        source.register(inboundSseEvent -> received.add(inboundSseEvent.readData()));
         source.open();
 
         // trigger the analysis

--- a/src/test/java/org/jboss/windup/web/rest/WindupE2EIT.java
+++ b/src/test/java/org/jboss/windup/web/rest/WindupE2EIT.java
@@ -1,0 +1,108 @@
+package org.jboss.windup.web.rest;
+
+import io.restassured.http.ContentType;
+import io.restassured.http.Headers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.sse.SseEventSource;
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WindupE2EIT {
+
+    private static final String PATH = "windup";
+    private static String URL;
+
+    @BeforeAll
+    public static void init() {
+        URL = System.getProperty("windup.url", "");
+        assertFalse(URL.isEmpty(), "\"windup.url\" property not provided.\nAppend \"-Dwindup.url=$(minikube service -n windup api --url)\" to the command to set it.\n");
+    }
+
+    @Test
+    public void testWindupPostAnalysisEndpoint() {
+        // start the SSE listener immediately
+        final Client client = ClientBuilder.newClient();
+        final WebTarget target = client.target(String.format("%s/%s/analysisSse/", URL, PATH));
+        final List<String> received = new CopyOnWriteArrayList<>();
+        final SseEventSource source = SseEventSource.target(target).build();
+        source.register(inboundSseEvent -> {
+            System.out.println("inboundSseEvent = " + inboundSseEvent.readData());
+            received.add(inboundSseEvent.readData());
+        });
+        source.open();
+
+        // trigger the analysis
+        final File sampleApplication = new File("src/main/resources/META-INF/resources/samples/jee-example-app-1.0.0.ear");
+        assertTrue(sampleApplication.exists());
+        final Headers headers = given()
+                .multiPart("application", sampleApplication)
+                .multiPart("applicationFileName","foo.ear")
+                .multiPart("targets","eap7,cloud-readiness,quarkus,rhr")
+                .when()
+                .post(String.format("%s/%s/analysis/", URL, PATH))
+                .then()
+                .statusCode(201)
+                .extract()
+                .headers();
+        final String location = headers.getValue("Location");
+        assertNotNull(location);
+        final String issuesLocation = headers.getValue("Issues-Location");
+        assertNotNull(issuesLocation);
+        final String analysisId = headers.getValue("Analysis-Id");
+        assertNotNull(analysisId);
+        assertTrue(issuesLocation.contains(analysisId));
+        assertTrue(location.endsWith(analysisId));
+
+        // wait for the analysis to finish
+        await()
+                .pollInterval(1, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.MINUTES)
+                .until(() -> given()
+                        .accept(ContentType.JSON)
+                        .contentType(ContentType.JSON)
+                        .when()
+                        .get(String.format("%s%s", URL, issuesLocation))
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .path("size()")
+                        .toString()
+                        .equals("92")
+                );
+
+        // close the SSE endpoint connection 
+        source.close();
+        // and check some "milestone" events have been sent even if the events have not all fixed value in fields
+        // so searching for some patterns will let the assertions do the validation
+        // check the "COMPLETED" event from the windup-executor pod has been sent
+        assertEquals(1, received.stream().filter(s -> s.contains("\"totalWork\":1581,\"workCompleted\":1582,\"currentTask\":\"PostFinalizePhase - DeleteWorkDirsAtTheEndRuleProvider - DeleteWorkDirsAtTheEndRuleProvider_2\"")).count());
+        // check the merge finished event has been sent
+        assertTrue(received.contains(String.format("{\"id\":%s,\"state\":\"MERGED\",\"currentTask\":\"Merged into central graph\",\"totalWork\":1,\"workCompleted\":1}", analysisId)));
+
+        // check the endpoint for retrieving all the issues is working with the analysis ID as query param
+        given()
+                .queryParam("analysisId", analysisId)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .when()
+                .get(String.format("%s/%s/issue", URL, PATH))
+                .then()
+                .statusCode(200)
+                .body("size()", is(92));
+    }
+}


### PR DESCRIPTION
resolves #41
resolves #42 

This PR introduces a first version of an end-to-end test for the currently available endpoints:

- it opens a connection to the SSE endpoint to get all the events without missing one
- it triggers an analysis uploading the sample application with some targets
- it waits for the issues to be available at the URL defined in an header coming from the previous call's response
- it checks some "milestone" event have been sent alone the analysis
- it checks the endpoint for retrieving all the issues works with the analysis ID parameter

The E2E test is, currently, the only test executed against all PRs, each merge into `main` branch and also daily at 8 AM UTC (maybe too much?)