### PR TITLE
Use setup-java action's cache

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -35,13 +35,7 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
           java-package: jdk
-
-      - name: Cache Maven packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: 'maven'
 
       - name: Build Tackle Windup API container image
         run: |


### PR DESCRIPTION
To avoid using the cache action.